### PR TITLE
feat: add 2 tests for format_message in MissingParameter

### DIFF
--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -553,6 +553,28 @@ def test_missing_option_string_cast():
     assert str(excinfo.value) == "Missing parameter: a"
 
 
+# -------------------------------------------------------------------
+# test 1 for format_message
+def test_format_message_missing_parameter():
+    from click.exceptions import MissingParameter
+    error = MissingParameter(param_type="parameter")
+    expected_message = "Missing parameter."
+    actual_message = error.format_message()
+
+    assert actual_message == expected_message, f"Expected '{expected_message}', but got '{actual_message}'"
+
+
+# test 2 for format_message
+def test_format_message_without_param_type():
+    from click.exceptions import MissingParameter
+    error = MissingParameter(param_type="")
+    expected_message = "Missing ."
+    actual_message = error.format_message()
+
+    assert actual_message == expected_message, f"Expected '{expected_message}', but got '{actual_message}'"
+# -------------------------------------------------------------------
+
+
 def test_missing_required_flag(runner):
     cli = click.Command(
         "cli", params=[click.Option(["--on/--off"], is_flag=True, required=True)]


### PR DESCRIPTION
Add 2 tests for testing format_message. One for param_type=parameter and one without a param_type.

closes #8

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
